### PR TITLE
Fix corrupted iso upload

### DIFF
--- a/project/metadata.json
+++ b/project/metadata.json
@@ -1,6 +1,6 @@
 {
     "externalUuid4": "72cd40ea-d0ee-4b40-a6a8-0458c5255088", 
-    "key": "pikvmapis", 
-    "name": "PiKVM-APIs", 
+    "key": "pikvmapisonmacosorlinux", 
+    "name": "PiKVM APIs on macOS or Linux", 
     "revision": "145c6dc54454"
 }

--- a/steps/uploadimage/script.txt
+++ b/steps/uploadimage/script.txt
@@ -1,7 +1,10 @@
 upload_file=$(curl -k -X POST -T "{workerBaseDirectory}/kickstart_{newLinuxNode.fqn}.iso" \
     "https://{pikvmIpAddress}/api/msd/write?image=kickstart_{newLinuxNode.fqn}.iso" \
     -H "X-KVMD-User: {pikvmUserAdmin.user}" \
-    -H "X-KVMD-Passwd: {pikvmUserAdmin.password}")
+    -H "X-KVMD-Passwd: {pikvmUserAdmin.password}" \
+    -H "Content-Type: application/octet-stream" \
+    --max-time 600 \
+    --tcp-nodelay)
 
 msd_state=$(curl -s -k -X GET \
     "https://{pikvmIpAddress}/api/msd" \


### PR DESCRIPTION
Set the HTTP Content-Type header to indicate binary data.
Set a ten minute timer to prevent the curl command from timing out.
Disabled tcp buffering to sent data immediately and reduce corruption risk.